### PR TITLE
Added support for self-signed certificate

### DIFF
--- a/src/PaypalIPNListener.php
+++ b/src/PaypalIPNListener.php
@@ -100,7 +100,7 @@ class PaypalIPNListener
 
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, !$this->use_sandbox);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_CAINFO,
             __DIR__ . '/cert/api_cert_chain.crt');


### PR DESCRIPTION
Thanks for making this plugin, very useful. Here's my small contribution to it.

This pull requests solves development testing issues when using a self-signed ssl certificate:

cURL error: [60] SSL certificate problem: unable to get local issuer certificate
