### PR TITLE
Private variables/methods made protected

### DIFF
--- a/src/PaypalIPNListener.php
+++ b/src/PaypalIPNListener.php
@@ -69,10 +69,10 @@ class PaypalIPNListener
      */
     public $timeout = 30;
 
-    private $post_data = array();
-    private $post_uri = '';
-    private $response_status = '';
-    private $response = '';
+    protected $post_data = array();
+    protected $post_uri = '';
+    protected $response_status = '';
+    protected $response = '';
 
     const PAYPAL_HOST = 'www.paypal.com';
     const SANDBOX_HOST = 'www.sandbox.paypal.com';
@@ -175,7 +175,7 @@ class PaypalIPNListener
         fclose($fp);
     }
 
-    private function getPaypalHost()
+    protected function getPaypalHost()
     {
         if ($this->use_sandbox) return self::SANDBOX_HOST;
         else return self::PAYPAL_HOST;


### PR DESCRIPTION
Since this project is no longer maintained, people who would still like to use it should create a child class of the original implementation and make changes in the child class. To do this, we need to open up private declarations as protected.

For example, the PAYPAL_HOST & SANDBOX_HOST used in this project are incorrect (should be ipnpb.paypal.com & ipnpb.sandbox.paypal.com). Since these are const values, they cannot be changed even in child classes. However, we could override the getPaypalHost method in a child class and make it return the correct urls.